### PR TITLE
refactor remove singleton from viewmodel

### DIFF
--- a/MemberCardApp/MemberCardApp/View/AddEditViewController.swift
+++ b/MemberCardApp/MemberCardApp/View/AddEditViewController.swift
@@ -16,7 +16,7 @@ final class AddEditViewController: UIViewController {
     // 이미지 로더 인스턴스 생성
     private let imageLoader = ImageLoader()
     // 회원 정보를 관리하는 뷰 모델
-    private let memberViewModel = MemberViewModel.shared
+    private let memberViewModel = MemberViewModel()
     
     var member: Member
     

--- a/MemberCardApp/MemberCardApp/View/AddEditViewController.swift
+++ b/MemberCardApp/MemberCardApp/View/AddEditViewController.swift
@@ -16,7 +16,13 @@ final class AddEditViewController: UIViewController {
     // 이미지 로더 인스턴스 생성
     private let imageLoader = ImageLoader()
     // 회원 정보를 관리하는 뷰 모델
-    private let memberViewModel = MemberViewModel()
+    private let viewModel: MemberViewModel
+    
+    init(member: Member, viewModel: MemberViewModel) {
+        self.member = member
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
     
     var member: Member
     
@@ -25,12 +31,6 @@ final class AddEditViewController: UIViewController {
     
     // 삭제 예정
     var editMode: Bool?
-    
-    // member 객체를 전달받아 초기화
-    init(member: Member){
-        self.member = member
-        super.init(nibName: nil, bundle: nil)
-    }
     
     // 스토리보드 X
     required init?(coder: NSCoder) {
@@ -114,11 +114,10 @@ final class AddEditViewController: UIViewController {
         
         // 기존에 멤버가 존재하면 업데이트, 아닐경우 새로 추가
         if editMode ?? false {
-            memberViewModel.updateMember(id: self.member.id, name: name, imageURL: imageURL, content: content)
+            viewModel.updateMember(id: self.member.id, name: name, imageURL: imageURL, content: content)
         } else {
-            memberViewModel.addMember(name: name, imageURL: imageURL, content: content)
+            viewModel.addMember(name: name, imageURL: imageURL, content: content)
         }
-        
         // 이전 화면으로 이동
         self.navigationController?.popViewController(animated: true)
     }

--- a/MemberCardApp/MemberCardApp/View/DetailViewController.swift
+++ b/MemberCardApp/MemberCardApp/View/DetailViewController.swift
@@ -10,8 +10,8 @@ import UIKit
 final class DetailViewController: UIViewController {
 
     private var member: Member
-    private let viewModel = MemberViewModel()
-    
+    private let viewModel: MemberViewModel
+
     // 상단 버튼 2개
     private lazy var deleteButton = makeButton(title: "삭제")
     private lazy var editButton = makeButton(title: "편집")
@@ -43,12 +43,12 @@ final class DetailViewController: UIViewController {
         return label
     }()
     
-    init(member: Member) {
+    init(member: Member, viewModel: MemberViewModel) {
         self.member = member
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-        
-        // 멤버 이미지 로드
         loadImage(into: imageView, from: member.imageURL)
+
     }
     
     required init?(coder: NSCoder) {
@@ -73,6 +73,7 @@ final class DetailViewController: UIViewController {
         contentText.text = member.content
         loadImage(into: imageView, from: member.imageURL)
     }
+ 
     
     private func setupUI() {
         // 스크롤 뷰
@@ -117,7 +118,7 @@ final class DetailViewController: UIViewController {
     }
     
     @objc private func editButtonTapped() {
-        self.navigationController?.pushViewController(AddEditViewController(member: member),animated: true)
+        self.navigationController?.pushViewController(AddEditViewController(member: member, viewModel: viewModel),animated: true)
     }
     
     @objc private func deleteButtonTapped() {

--- a/MemberCardApp/MemberCardApp/View/DetailViewController.swift
+++ b/MemberCardApp/MemberCardApp/View/DetailViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class DetailViewController: UIViewController {
 
     private var member: Member
-    private let viewModel = MemberViewModel.shared
+    private let viewModel = MemberViewModel()
     
     // 상단 버튼 2개
     private lazy var deleteButton = makeButton(title: "삭제")

--- a/MemberCardApp/MemberCardApp/View/MainViewController.swift
+++ b/MemberCardApp/MemberCardApp/View/MainViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 final class MainViewController: UIViewController {
     
     // MARK: - Properties
-    private var viewModel = MemberViewModel.shared
+    private var viewModel = MemberViewModel()
     var dataSource: UICollectionViewDiffableDataSource<MainSection, MainItem>?
     var sections: [MainSection] = []
     

--- a/MemberCardApp/MemberCardApp/View/MainViewController.swift
+++ b/MemberCardApp/MemberCardApp/View/MainViewController.swift
@@ -49,6 +49,7 @@ final class MainViewController: UIViewController {
     // 뷰모델의 멤버 데이터가 갱신되면 컬렉션뷰 스냅샷 업데이트
     private func bindViewModel() {
         viewModel.onMembersUpdated = { [weak self] members in
+            print("onMembersUpdated 호출됨") // 디버깅용
             DispatchQueue.main.async {
                 self?.updateSnapshot(with: members)
             }
@@ -72,13 +73,13 @@ extension MainViewController: UICollectionViewDelegate {
         if isAddMemberCell(indexPath: indexPath) {
             // 멤버 추가 화면으로 이동
             self.navigationController?.pushViewController(
-                AddEditViewController(member: member),
+                AddEditViewController(member: member, viewModel: viewModel),
                 animated: true
             )
         } else {
             // 선택한 멤버 상세화면으로 이동
             self.navigationController?.pushViewController(
-                DetailViewController(member: member),
+                DetailViewController(member: member, viewModel: viewModel),
                 animated: true
             )
         }

--- a/MemberCardApp/MemberCardApp/ViewModel/MemberViewModel.swift
+++ b/MemberCardApp/MemberCardApp/ViewModel/MemberViewModel.swift
@@ -7,34 +7,55 @@
 
 import Foundation
 
-class MemberViewModel {
-    static let shared = MemberViewModel()
+class MemberStore {
+    static let shared = MemberStore()
     
-    private let repository: MemberRepository
+    private init() {}
 
-    init(repository: MemberRepository = MemberRepository()) {
-        self.repository = repository
-    }
-    
-    // 뷰 업데이트를 위한 클로저
-    var onMembersUpdated: (([Member])->Void)?
-    
-    private(set) var members: [Member] = []
-    
-    func fetchMembers() {
-        Task {
-            self.members = await repository.getMembers()
-            onMembersUpdated?(self.members) // members 데이터 변경후 뷰 업데이트 클로저 실행
+    private(set) var members: [Member] = [] {
+        didSet {
+            onMembersUpdated?(members)
         }
     }
     
+    var onMembersUpdated: (([Member]) -> Void)?
+    
+    func updateMembers(_ newMembers: [Member]) {
+        self.members = newMembers
+    }
+}
+
+class MemberViewModel {
+    private let repository: MemberRepository
+    private var store = MemberStore.shared
+    
+    var onMembersUpdated: (([Member]) -> Void)?
+
+    init(repository: MemberRepository = MemberRepository()) {
+        self.repository = repository
+        store.onMembersUpdated = { [weak self] updatedMembers in
+            self?.onMembersUpdated?(updatedMembers)
+        }
+    }
+
+    var members: [Member] {
+        return store.members
+    }
+
+    func fetchMembers() {
+        Task {
+            let fetchedMembers = await repository.getMembers()
+            store.updateMembers(fetchedMembers)
+        }
+    }
+
     func addMember(name: String, imageURL: String, content: String) {
         Task {
             await repository.addMember(name: name, imageURL: imageURL, content: content)
             fetchMembers()
         }
     }
-    
+
     func updateMember(id: UUID, name: String?, imageURL: String?, content: String?) {
         Task {
             let updateData = UpdateMemberData(name: name, imageURL: imageURL, content: content)
@@ -42,7 +63,7 @@ class MemberViewModel {
             fetchMembers()
         }
     }
-    
+
     func deleteMember(id: UUID) {
         Task {
             await repository.deleteMember(id: id)
@@ -50,3 +71,4 @@ class MemberViewModel {
         }
     }
 }
+

--- a/MemberCardApp/MemberCardApp/ViewModel/MemberViewModel.swift
+++ b/MemberCardApp/MemberCardApp/ViewModel/MemberViewModel.swift
@@ -7,45 +7,26 @@
 
 import Foundation
 
-class MemberStore {
-    static let shared = MemberStore()
-    
-    private init() {}
+class MemberViewModel {
+    private let repository: MemberRepository
 
     private(set) var members: [Member] = [] {
         didSet {
             onMembersUpdated?(members)
         }
     }
-    
-    var onMembersUpdated: (([Member]) -> Void)?
-    
-    func updateMembers(_ newMembers: [Member]) {
-        self.members = newMembers
-    }
-}
 
-class MemberViewModel {
-    private let repository: MemberRepository
-    private var store = MemberStore.shared
-    
     var onMembersUpdated: (([Member]) -> Void)?
 
     init(repository: MemberRepository = MemberRepository()) {
         self.repository = repository
-        store.onMembersUpdated = { [weak self] updatedMembers in
-            self?.onMembersUpdated?(updatedMembers)
-        }
     }
 
-    var members: [Member] {
-        return store.members
-    }
-
+    
     func fetchMembers() {
         Task {
-            let fetchedMembers = await repository.getMembers()
-            store.updateMembers(fetchedMembers)
+            self.members = await repository.getMembers()
+            onMembersUpdated?(self.members)
         }
     }
 
@@ -71,4 +52,3 @@ class MemberViewModel {
         }
     }
 }
-


### PR DESCRIPTION
memverviewmodel을 싱글톤으로 만들경우 클로저를 여러 viewcontroller에서 정의할경우 덮어씌어질 위험이 있어서 제거하고, memverviewmodel을 mainViewcontroller에서 인스턴스 생성을 하고, 이후 페이지 이동시 뷰모델을 의존성 주입하는 방식으로 전달하게 만들었습니다.